### PR TITLE
Repo and Cluster View UX Improvements

### DIFF
--- a/packages/web/app/components/GitHubIssue.vue
+++ b/packages/web/app/components/GitHubIssue.vue
@@ -39,9 +39,9 @@ function labelColors(color: string) {
 </script>
 
 <template>
-  <article class="flex flex-row gap-2 leading-tightest">
-    <span class="flex-shrink-0 inline-block w-5 h-5 i-tabler-circle-dot text-green-500" />
-    <div class="flex flex-row gap-2 flex-wrap md:flex-nowrap md:pb-6 flex-grow">
+  <article class="border-solid border border-gray-600 rounded-md max-w-full overflow-hidden flex flex-row gap-2 leading-tightest">
+    <span class="flex-shrink-0 inline-block h-5 i-tabler-circle-dot text-green-500" />
+    <div class="flex flex-col flex-wrap md:flex-nowrap md:pb-2 flex-grow">
       <NuxtLink
         class="line-clamp-1 flex-grow text-sm md:text-base lg:flex-grow-0 no-underline color-current hover:underline"
         :href="url"
@@ -50,7 +50,7 @@ function labelColors(color: string) {
         {{ title?.trim() }}
       </NuxtLink>
       <div
-        class="text-xs relative md:absolute md:mt-6 text-gray-400 mb-1"
+        class=" text-xs relative md:mt-1 text-gray-400 mb-1 break-words"
       >
         <NuxtLink
           v-if="owner && repository"

--- a/packages/web/app/pages/[owner]/[repo]/index.vue
+++ b/packages/web/app/pages/[owner]/[repo]/index.vue
@@ -160,13 +160,14 @@ const openState = reactive<Record<string, boolean>>({})
       </section>
     </template>
     <template v-else>
+      <section class="grid grid-cols-4 gap-4 ">
       <section
         v-for="(cluster, c) of clusters"
         :key="c"
         :style="{ '--section-index': c }"
-        class="flex flex-col gap-4 md:rounded-md md:border-solid md:border border-gray-700 md:px-4 pb-8 mt-6 columns-1 lg:columns-2 border-b-solid"
+        class=" overflow-hidden flex flex-col gap-4 md:rounded-md md:border-solid md:border border-gray-700 md:px-4 pb-8 mt-6 columns-1 lg:columns-2 border-b-solid"
       >
-        <h2 class="my-4 font-bold text-2xl flex items-baseline">
+        <h2 class=" my-4 font-bold text-2xl flex items-baseline">
           <span class="text-gray-500 inline-block mr-1 font-normal">#</span>{{ c + 1 }}
           <span class="ml-2 font-normal text-lg color-gray-300">&mdash; {{ cluster.title }}</span>
           <span class="ml-auto text-white bg-gray-700 text-sm font-normal rounded-full px-2 py-0.5 whitespace-pre border-solid border-1 border-gray-700 inline-block leading-tight flex items-center">
@@ -194,6 +195,7 @@ const openState = reactive<Record<string, boolean>>({})
         >
           show {{ cluster.issues.length - 5 }} more
         </button>
+      </section>
       </section>
     </template>
   </div>


### PR DESCRIPTION
## Context
Currently the Repo and Cluster Views (my terms) are not conducive to furthering a maintainer's understanding of their project's outstanding issues at a high-level, this work aims to provide a better experience when viewing all of a given repo's issues.  Further documentation will be provided in the conversation for the attached issue.

**NOTE: This is very much work-in-progress, it is not intended as the final state, more-so a vehicle to carry the conversation forward.**

Current State:
![image](https://github.com/user-attachments/assets/2cb48dd3-2413-41e0-a9c2-309183bc5233)

## Addresses:
[Issue-19](https://github.com/danielroe/unsight.dev/issues/19)