### PR TITLE
refactor(web): improved  type safety of chunkIssue() & getLabels() fn signatures

### DIFF
--- a/packages/web/server/utils/embeddings.ts
+++ b/packages/web/server/utils/embeddings.ts
@@ -4,6 +4,10 @@ import { hash } from 'ohash'
 
 type RestIssue = RestEndpointMethodTypes['issues']['get']['response']['data']
 
+export const issueSegments = { labels: 'labels', title: 'title', body: 'body' } as const
+
+export type IssueSegments = (typeof issueSegments)[keyof typeof issueSegments]
+
 export function storageKeyForIssue(owner: string, repo: string, number: number | string) {
   return `issue:${owner}:${repo}:${number}`
 }
@@ -136,9 +140,9 @@ function preprocessText(text: string): string {
     .trim()
 }
 
-export function chunkIssue(issue: Pick<Issue | RestIssue, 'labels' | 'title' | 'body'>, exclude?: Set<string>) {
+export function chunkIssue(issue: Pick<Issue | RestIssue, IssueSegments>, exclude?: Set<string>) {
   const labels = getLabels(issue).filter(l => !exclude?.has(l))
-  return preprocessText(`${issue.title}\n${labels.join(', ')}\n${issue.body}`)
+  return preprocessText(`${issue[issueSegments.title]}\n${labels.join(', ')}\n${issue[issueSegments.body]}`)
 }
 
 async function generateEmbedding(text: string): Promise<number[]> {
@@ -152,6 +156,6 @@ async function generateEmbedding(text: string): Promise<number[]> {
   }
 }
 
-function getLabels(issue: Pick<Issue | RestIssue, 'labels' | 'title' | 'body'>) {
+function getLabels(issue: Pick<Issue | RestIssue, IssueSegments>) {
   return issue.labels?.map(label => (typeof label === 'string' ? label : label.name!).toLowerCase()).filter(Boolean) || []
 }

--- a/packages/web/server/utils/embeddings.ts
+++ b/packages/web/server/utils/embeddings.ts
@@ -4,9 +4,7 @@ import { hash } from 'ohash'
 
 type RestIssue = RestEndpointMethodTypes['issues']['get']['response']['data']
 
-export const issueSegments = { labels: 'labels', title: 'title', body: 'body' } as const
-
-export type IssueSegments = (typeof issueSegments)[keyof typeof issueSegments]
+export type IssueSegments = 'labels' | 'title' | 'body'
 
 export function storageKeyForIssue(owner: string, repo: string, number: number | string) {
   return `issue:${owner}:${repo}:${number}`
@@ -142,7 +140,7 @@ function preprocessText(text: string): string {
 
 export function chunkIssue(issue: Pick<Issue | RestIssue, IssueSegments>, exclude?: Set<string>) {
   const labels = getLabels(issue).filter(l => !exclude?.has(l))
-  return preprocessText(`${issue[issueSegments.title]}\n${labels.join(', ')}\n${issue[issueSegments.body]}`)
+  return preprocessText(`${issue.title}\n${labels.join(', ')}\n${issue.body}`)
 }
 
 async function generateEmbedding(text: string): Promise<number[]> {


### PR DESCRIPTION
## Context

Just doing as I'm told. 🫡 [Volun-told](https://github.com/danielroe/unsight.dev/pull/109#issuecomment-2726788482)

This PR follows up on the conversation from [PR-109](https://github.com/danielroe/unsight.dev/pull/109) to take advantage of a mapped type w/`as const` in order to benefit from stricter type safety/inference.