### PR TITLE
feat: add basic tooltip for truncated title spans

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.8.0",
   "scripts": {
     "dev": "pnpm --filter web dev",
+    "dev:ext": "pnpm --filter unsight dev",
     "lint": "eslint --cache .",
     "test:types": "pnpm -r test:types",
     "test:unit": "pnpm -r test:unit",

--- a/packages/extension/entrypoints/github-issues.content/App.vue
+++ b/packages/extension/entrypoints/github-issues.content/App.vue
@@ -43,7 +43,7 @@ function formatDate (date: Date) {
           
           <svg v-else class="octicon octicon-issue-closed closed" title="Closed" aria-label="Closed issue" viewBox="0 0 16 16" version="1.1" width="16" height="16" role="img" style="color: #a371f7;"><path d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"></path><path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"></path></svg>
           
-          <span class="ml-2 !text-white">
+          <span class="ml-2 !text-white" :title="issue.title">
             {{ issue.title }}
           </span>
           <br>


### PR DESCRIPTION
This add the issue title to the title span to be able to see the full title if its truncated.

![image](https://github.com/user-attachments/assets/5d9736c4-9769-4033-9656-45d626ed770b)
