### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unsight-dev",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "dev": "vp run --filter web dev",
     "dev:ext": "vp run --filter unsight dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,9 +8,12 @@ trustPolicyExclude:
 packages:
   - packages/*
 
-ignoredBuiltDependencies:
-  - esbuild
-  - workerd
-
-onlyBuiltDependencies:
-  - simple-git-hooks
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  sharp: false
+  simple-git-hooks: true
+  spawn-sync: false
+  unrs-resolver: false
+  vue-demi: false
+  workerd: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`